### PR TITLE
removed unnecessary sigmoid in classification.

### DIFF
--- a/model/mfad.py
+++ b/model/mfad.py
@@ -86,7 +86,6 @@ class FAD_HAM_Net(nn.Module):
         x = self.bn(x)
         x = self.drop(x)
         x = self.cls(x)
-        x = torch.sigmoid(x) # check num_class
         return x, map_x
 
 


### PR DESCRIPTION
WeightedFocalLoss uses binary_cross_entropy_with_logits which expects inputs without sigmoid. From PyTorch documentation: "This loss combines a Sigmoid layer and the BCELoss in one single class.". [Source](https://pytorch.org/docs/stable/generated/torch.nn.BCEWithLogitsLoss.html#torch.nn.BCEWithLogitsLoss) So no need to add Sigmoid at the end of classification branch.